### PR TITLE
Allow Alchemy 7.0

### DIFF
--- a/alchemy-sentry.gemspec
+++ b/alchemy-sentry.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{lib}/**/*", "LICENSE", "Rakefile", "README.md"]
 
-  spec.add_dependency "alchemy_cms", ">= 4.6.7", "< 7"
+  spec.add_dependency "alchemy_cms", ">= 4.6.7", "< 8"
   spec.add_dependency "sentry-ruby", "~> 5.0"
   spec.add_dependency "sentry-rails", "~> 5.0"
 end


### PR DESCRIPTION
Allow the latest version of AlchemyCMS. The Gem does not have to have anymore changes except of the allowed dependency.